### PR TITLE
issue - 18: Added block Library

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,13 @@
+{
+  "project": "ICICI Direct",
+  "host": "main--icicidirect--aemsites.hlx.live",
+  "plugins": [
+    {
+      "id": "library",
+      "title": "Library",
+      "environments": [ "edit" ],
+      "url": "/tools/sidekick/library.html",
+      "includePaths": [ "**.docx**" ]
+    }
+  ]
+}

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="Description" content="AEM Sidekick Library" />
+    <meta name="robots" content="noindex" />
+    <base href="/" />
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: sans-serif;
+        background-color: #ededed;
+        height: 100%;
+      }
+
+      helix-sidekick { display: none }
+    </style>
+    <title>Sidekick Library</title>
+  </head>
+
+  <body>
+    <script
+      type="module"
+      src="https://www.hlx.live/tools/sidekick/library/index.js"
+    ></script>
+    <script>
+      const library = document.createElement('sidekick-library')
+      library.config = {
+        base: '/sidekick/library.json',
+        icons: '/tools/sidekick/plugins/icons/icons.js',
+        placeholders: '/tools/sidekick/plugins/placeholders/placeholders.js'
+      }
+
+      document.body.prepend(library)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Added Block Library. It is accessible [though the URL](https://main--icicidirect--aemsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/&index=0)
Fix #18 

Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/
- After: https://issue-18-v1--icicidirect--aemsites.hlx.live/
