### PR TITLE
Enhancement in quicklinks for tabs handling

### DIFF
--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -137,6 +137,6 @@ export default async function decorate(block) {
   const parentContainer = document.querySelector('.section.quicklinks-container');
   enableStickyBehaviorForQuickLinks(parentContainer, block);
   // enable the section highlighting when quicklinks comes into viewport
-  // this gives the quicklinks sometime so that other sections are ready 
+  // this gives the quicklinks sometime so that other sections are ready
   observe(block, enableSectionHighligting);
 }

--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -1,9 +1,5 @@
 import { readBlockConfig } from '../../scripts/aem.js';
-
-const options = {
-  root: null,
-  threshold: 0.7,
-};
+import { observe } from '../../scripts/blocks-utils.js';
 
 /**
  * Marks the link in the quicklinks section as active for the section visible in the view port
@@ -86,6 +82,22 @@ const preventInternalLinksDefault = (quickLinkItem, sectionId) => {
     event.preventDefault();
     const targetSection = document.getElementById(sectionId);
     scrollToAdjustedStickyHeader(targetSection);
+    activateSectionInView(sectionId);
+  });
+};
+
+/**
+ * Enable highlighting of all sections when come into viewport
+ */
+const enableSectionHighligting = () => {
+  const quickLinkEnabledBlocks = document.querySelectorAll('[data-quicklinks-title]');
+  const options = {
+    root: null,
+    threshold: 0.7,
+  };
+  const observer = new IntersectionObserver(handlePageSectionIntersection, options);
+  quickLinkEnabledBlocks.forEach((singleBlock) => {
+    observer.observe(singleBlock);
   });
 };
 
@@ -109,7 +121,6 @@ export default async function decorate(block) {
   const quickLinkEnabledBlocksOrTabs = document.querySelectorAll('[data-quicklinks-title]');
 
   // Create a new intersection observer
-  const observer = new IntersectionObserver(handlePageSectionIntersection, options);
   quickLinkEnabledBlocksOrTabs.forEach((singleItem) => {
     const linkId = singleItem.id;
     const linkTitle = singleItem.getAttribute('data-quicklinks-title');
@@ -119,12 +130,13 @@ export default async function decorate(block) {
     quickLinkContainerDiv.appendChild(linkNode);
     // prevent quicklinks default behaviour
     preventInternalLinksDefault(linkNode, linkId);
-    // observe other sections of the page when scrolled
-    observer.observe(singleItem);
   });
   block.append(quickLinkContainerDiv);
 
   // enable sticky quicklinks when page is scrolled
   const parentContainer = document.querySelector('.section.quicklinks-container');
   enableStickyBehaviorForQuickLinks(parentContainer, block);
+  // enable the section highlighting when quicklinks comes into viewport
+  // this gives the quicklinks sometime so that other sections are ready 
+  observe(block, enableSectionHighligting);
 }

--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -22,8 +22,8 @@ const activateSectionInView = (elementId) => {
  * Function to handle the intersecting section of the page with quicklink enabled
  */
 const handlePageSectionIntersection = (entries) => {
-  entries.forEach((entry) => {
-    if (entry.isIntersecting) {
+  entries.forEach((entry, index) => {
+    if (entry.isIntersecting && index === 0) {
       const elementId = entry.target.id;
       activateSectionInView(elementId);
     }
@@ -82,7 +82,7 @@ const preventInternalLinksDefault = (quickLinkItem, sectionId) => {
     event.preventDefault();
     const targetSection = document.getElementById(sectionId);
     scrollToAdjustedStickyHeader(targetSection);
-    activateSectionInView(sectionId);
+    setTimeout(() => activateSectionInView(sectionId), 200);
   });
 };
 
@@ -93,7 +93,7 @@ const enableSectionHighligting = () => {
   const quickLinkEnabledBlocks = document.querySelectorAll('[data-quicklinks-title]');
   const options = {
     root: null,
-    threshold: 0.7,
+    threshold: 0.5,
   };
   const observer = new IntersectionObserver(handlePageSectionIntersection, options);
   quickLinkEnabledBlocks.forEach((singleBlock) => {

--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -1,4 +1,4 @@
-import { readBlockConfig, toClassName } from '../../scripts/aem.js';
+import { readBlockConfig } from '../../scripts/aem.js';
 
 const options = {
   root: null,
@@ -17,7 +17,9 @@ const activateSectionInView = (elementId) => {
   });
   // Set new section as active which is in viewport
   const quickLinkElement = document.querySelector(`[href="#${elementId}"]`);
-  quickLinkElement.classList.add('active');
+  if (quickLinkElement) {
+    quickLinkElement.classList.add('active');
+  }
 };
 
 /**
@@ -26,10 +28,7 @@ const activateSectionInView = (elementId) => {
 const handlePageSectionIntersection = (entries) => {
   entries.forEach((entry) => {
     if (entry.isIntersecting) {
-      let elementId = entry.target.id;
-      if (entry.target.classList.contains('section') && elementId) {
-        elementId = `tab-${elementId}`;
-      }
+      const elementId = entry.target.id;
       activateSectionInView(elementId);
     }
   });
@@ -107,40 +106,21 @@ export default async function decorate(block) {
   // extract quicklinks from the complete page
   const quickLinkContainerDiv = document.createElement('div');
   quickLinkContainerDiv.className = 'quicklinks-container';
-  const quickLinkEnabledBlocksOrSection = document.querySelectorAll('[data-quicklinks-title]');
+  const quickLinkEnabledBlocksOrTabs = document.querySelectorAll('[data-quicklinks-title]');
 
   // Create a new intersection observer
   const observer = new IntersectionObserver(handlePageSectionIntersection, options);
-  quickLinkEnabledBlocksOrSection.forEach((singleItem) => {
-    const isSection = singleItem.classList.contains('section');
-    // in case of section look for all ids within the section that matches the name
-    if (isSection) {
-      // TODO: fetch tabs directly from tab list and set title as true
-      const linkTitles = singleItem.getAttribute('data-quicklinks-title').split(',');
-      linkTitles.forEach((singleTitle) => {
-        const linkId = `tab-${toClassName(singleTitle.trim())}`;
-        const linkTitle = singleTitle.trim();
-        const linkNode = document.createElement('a');
-        linkNode.href = `#${linkId}`;
-        linkNode.innerText = linkTitle;
-        quickLinkContainerDiv.appendChild(linkNode);
-        // prevent quicklinks default behaviour
-        preventInternalLinksDefault(linkNode, linkId);
-        // observe other sections of the page when scrolled
-        observer.observe(singleItem);
-      });
-    } else {
-      const linkId = singleItem.id;
-      const linkTitle = singleItem.getAttribute('data-quicklinks-title');
-      const linkNode = document.createElement('a');
-      linkNode.href = `#${linkId}`;
-      linkNode.innerText = linkTitle;
-      quickLinkContainerDiv.appendChild(linkNode);
-      // prevent quicklinks default behaviour
-      preventInternalLinksDefault(linkNode, linkId);
-      // observe other sections of the page when scrolled
-      observer.observe(singleItem);
-    }
+  quickLinkEnabledBlocksOrTabs.forEach((singleItem) => {
+    const linkId = singleItem.id;
+    const linkTitle = singleItem.getAttribute('data-quicklinks-title');
+    const linkNode = document.createElement('a');
+    linkNode.href = `#${linkId}`;
+    linkNode.innerText = linkTitle;
+    quickLinkContainerDiv.appendChild(linkNode);
+    // prevent quicklinks default behaviour
+    preventInternalLinksDefault(linkNode, linkId);
+    // observe other sections of the page when scrolled
+    observer.observe(singleItem);
   });
   block.append(quickLinkContainerDiv);
 

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -270,6 +270,9 @@ export default async function decorate(block) {
 
     // build tab button
     const button = document.createElement('button');
+    // TODO: copy all attributes of div into button
+    button.setAttribute('id', tab.id);
+    button.setAttribute('data-quicklinks-title', tab.getAttribute('data-quicklinks-title'));
     button.className = 'tabs-tab';
     button.innerHTML = tab.innerHTML;
     button.setAttribute('aria-controls', `tabpanel-${id}`);

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -270,9 +270,10 @@ export default async function decorate(block) {
 
     // build tab button
     const button = document.createElement('button');
-    // TODO: copy all attributes of div into button
-    button.setAttribute('id', tab.id);
-    button.setAttribute('data-quicklinks-title', tab.getAttribute('data-quicklinks-title'));
+    // copy all existing attributes of div into button
+    Array.from(tab.attributes).forEach((singleAttribute) => {
+      button.setAttribute(singleAttribute.name, singleAttribute.value);
+    });
     button.className = 'tabs-tab';
     button.innerHTML = tab.innerHTML;
     button.setAttribute('aria-controls', `tabpanel-${id}`);

--- a/scripts/blocks-utils.js
+++ b/scripts/blocks-utils.js
@@ -151,7 +151,18 @@ function getEnvType(hostname = window.location.hostname) {
  * @param {Element} main The container element under which quicklinks has to be enabled.
  */
 function decorateQuickLinks(main) {
-  const addQuickLinksMetadata = (block) => {
+  const handQuickLinksMetadataForTabs = (section) => {
+    const quickLinkTitles = section.getAttribute('data-quicklinks-title').split(',');
+    const nestedTabs = section.querySelectorAll('.block.tabs > div > div:first-child');
+    const nestedTabsIndexed = Array.from(nestedTabs);
+    // assign the ids as per the order of tabs
+    quickLinkTitles.forEach((singleTitle, index) => {
+      nestedTabsIndexed[index].id = toCamelCase(singleTitle.trim());
+      nestedTabsIndexed[index].setAttribute('data-quicklinks-title', singleTitle.trim());
+    });
+    section.removeAttribute('data-quicklinks-title');
+  };
+  const addQuickLinksMetadataForBlocks = (block) => {
     // extract the quicklinks details if present
     const blockConfig = readBlockConfig(block);
     const quickLinkTitle = blockConfig['quicklinks-title'];
@@ -160,7 +171,8 @@ function decorateQuickLinks(main) {
       block.id = toCamelCase(quickLinkTitle);
     }
   };
-  main.querySelectorAll('div.section-container > div > div').forEach(addQuickLinksMetadata);
+  main.querySelectorAll('div.tabs-container[data-quicklinks-title]').forEach(handQuickLinksMetadataForTabs);
+  main.querySelectorAll('div.section-container > div > div').forEach(addQuickLinksMetadataForBlocks);
 }
 
 export {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #99 

Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://quicklinksv2--icicidirect--aemsites.hlx.live/draft/vivesing/quicklinksv3

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. carousel | [doc-link](https://main--icicidirect--aemsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/carousel&index=0)

Usage: 
Tabs need to include this section metadata along with the ordered names to be shown in the quicklinks
<img width="577" alt="image" src="https://github.com/aemsites/icicidirect/assets/38683124/c4730e24-4c46-4beb-9f7a-f6be37ac0a02">

