### PR TITLE
Issue-84: Add AEM assets sidekick plugin

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -8,6 +8,16 @@
       "environments": [ "edit" ],
       "url": "/tools/sidekick/library.html",
       "includePaths": [ "**.docx**" ]
+    },
+    {
+      "id": "asset-library",
+      "title": "My Assets",
+      "environments": [ "edit" ],
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "isPalette": true,
+      "includePaths": [ "**.docx**" ],
+      "passConfig": true,
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
     }
   ]
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://issue-84--icicidirect--aemsites.hlx.live/research/equity

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. carousel | [doc-link](https://main--icicidirect--aemsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/carousel&index=0)
