### PR TITLE
Fixing quicklinks scroll

### DIFF
--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -71,15 +71,10 @@ const scrollToAdjustedStickyHeader = (section) => {
   const additionalOffset = paddingTop + extraIfNotSticky; // Add your desired offset here
   const elementPosition = section && section.getBoundingClientRect().top;
   const offsetPosition = elementPosition + window.scrollY - additionalOffset;
-  let scrollBehavior = 'smooth';
-  if (!section.getAttribute('clicked')) {
-    section.setAttribute('clicked', true);
-    scrollBehavior = 'instant';
-  }
 
   window.scrollTo({
     top: offsetPosition,
-    behavior: scrollBehavior,
+    behavior: 'smooth',
   });
 
   if (section) {

--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -59,14 +59,29 @@ const enableStickyBehaviorForQuickLinks = (parentContainer, block) => {
  * @param {*} section that needs to be scrolled on top
  */
 const scrollToAdjustedStickyHeader = (section) => {
-  const headerOffset = 70;
+  const sectionContainer = section.closest('.section');
+  const style = window.getComputedStyle(sectionContainer);
+  const paddingTop = parseFloat(style.getPropertyValue('padding-top'));
+  let extraIfNotSticky = 0;
+  if (!document.querySelector('.block.quicklinks.sticky')) {
+    const quickLinkBlock = document.querySelector('.block.quicklinks');
+    const quickLinkStyle = window.getComputedStyle(quickLinkBlock);
+    extraIfNotSticky = parseFloat(quickLinkStyle.getPropertyValue('height'));
+  }
+  const additionalOffset = paddingTop + extraIfNotSticky; // Add your desired offset here
   const elementPosition = section && section.getBoundingClientRect().top;
-  const offsetPosition = elementPosition + window.scrollY - headerOffset;
+  const offsetPosition = elementPosition + window.scrollY - additionalOffset;
+  let scrollBehavior = 'smooth';
+  if (!section.getAttribute('clicked')) {
+    section.setAttribute('clicked', true);
+    scrollBehavior = 'instant';
+  }
 
   window.scrollTo({
     top: offsetPosition,
-    behavior: 'smooth',
+    behavior: scrollBehavior,
   });
+
   if (section) {
     section.click();
   }
@@ -93,7 +108,7 @@ const enableSectionHighligting = () => {
   const quickLinkEnabledBlocks = document.querySelectorAll('[data-quicklinks-title]');
   const options = {
     root: null,
-    threshold: 0.5,
+    threshold: 0.8,
   };
   const observer = new IntersectionObserver(handlePageSectionIntersection, options);
   quickLinkEnabledBlocks.forEach((singleBlock) => {

--- a/blocks/quicklinks/quicklinks.js
+++ b/blocks/quicklinks/quicklinks.js
@@ -59,16 +59,14 @@ const enableStickyBehaviorForQuickLinks = (parentContainer, block) => {
  * @param {*} section that needs to be scrolled on top
  */
 const scrollToAdjustedStickyHeader = (section) => {
-  const sectionContainer = section.closest('.section');
-  const style = window.getComputedStyle(sectionContainer);
-  const paddingTop = parseFloat(style.getPropertyValue('padding-top'));
+  const stickyMinWidth = 45;
   let extraIfNotSticky = 0;
   if (!document.querySelector('.block.quicklinks.sticky')) {
     const quickLinkBlock = document.querySelector('.block.quicklinks');
     const quickLinkStyle = window.getComputedStyle(quickLinkBlock);
     extraIfNotSticky = parseFloat(quickLinkStyle.getPropertyValue('height'));
   }
-  const additionalOffset = paddingTop + extraIfNotSticky; // Add your desired offset here
+  const additionalOffset = stickyMinWidth + extraIfNotSticky; // Add your desired offset here
   const elementPosition = section && section.getBoundingClientRect().top;
   const offsetPosition = elementPosition + window.scrollY - additionalOffset;
 


### PR DESCRIPTION
- wrong position issue
- without full page load issue

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #177 

Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://quiklinks-fix--icicidirect--aemsites.hlx.live/research/equity
