### PR TITLE
Auto pop for ipo block

### DIFF
--- a/blocks/ipo/ipo.js
+++ b/blocks/ipo/ipo.js
@@ -128,13 +128,10 @@ function createIPODots(block, totalCards, maxAllowedCards, dots) {
   }
 }
 
-async function createIPOPanel(block, knowMoreButton) {
+async function createIPOPanel(block, knowMoreButton, blockConfig) {
   let cardWidth;
   const track = block.querySelector('.track');
   const dots = block.querySelector('.dots-container');
-  if (track.offsetWidth) {
-    cardWidth = track.offsetWidth / allowedCardsCount();
-  }
   const callback = async (error, apiResponse = []) => {
     /*  if (apiResponse) {
       const result = [];
@@ -143,6 +140,20 @@ async function createIPOPanel(block, knowMoreButton) {
         jsonObject[item.Key] = item.Value;
       });
       result.push(jsonObject); */
+    const sideViewCardLimit = blockConfig.sideviewcardlimit || 2;
+    if (apiResponse.length > sideViewCardLimit) {
+      const { classList } = block.closest('.section.ipo-container');
+      if (!classList.contains('force-layout')) {
+        Array.from(classList).forEach((className) => {
+          if (/^layout-\d+-\d+$/.test(className)) {
+            block.closest('.section.ipo-container').classList.remove(className);
+          }
+        });
+      }
+    }
+    if (track.offsetWidth) {
+      cardWidth = track.offsetWidth / allowedCardsCount();
+    }
     createIPOCards(track, apiResponse, knowMoreButton, cardWidth);
     createIPODots(block, apiResponse.length, allowedCardsCount(), dots);
     // }
@@ -179,5 +190,5 @@ export default async function decorate(block) {
   dots.className = 'dots-container';
   slider.appendChild(track);
   slider.appendChild(dots);
-  observe(block, createIPOPanel, knowMoreButton);
+  observe(block, createIPOPanel, knowMoreButton, blockConfig);
 }

--- a/scripts/mock-upcoming-ipodata.json
+++ b/scripts/mock-upcoming-ipodata.json
@@ -22,5 +22,11 @@
         "IpoFullName": "Bharti Upcoming Hexacom IPO-4",
         "IPOEventStartDate": "03 Apr 2024",
         "IPOEventEndDate": "05 Apr 2024"
+    },
+    {
+        "IPOLogoImage": "https://www.icicidirect.com/images//Bharti Hexacom Logo-202403271411036233854.png",
+        "IpoFullName": "Bharti Upcoming Hexacom IPO-5",
+        "IPOEventStartDate": "03 Apr 2024",
+        "IPOEventEndDate": "05 Apr 2024"
     }
   ]


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #212 

Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://ipo-auto-pop--icicidirect--aemsites.hlx.live/research/equity

Requirement 

> Default : Both block should show side-by-side when only one IPO , at the moment if IPOs > 1 , automatically Upcoming IPO block should be removed from side-by-side view and start shown as standalone.
Author's control :- Author can place upcoming IPO block either in side-by-side view or standalone forcefully regardless number IPOs.
at a time only one of these would be applicable.

Default:
<img width="656" alt="image" src="https://github.com/aemsites/icicidirect/assets/46780200/b0c871b0-02e2-4263-874e-0d67d823b127">

Author's Control: `force-layout` style would not allow to remove `layout-x-x` styles.
<img width="662" alt="image" src="https://github.com/aemsites/icicidirect/assets/46780200/0554ba7c-dfc9-4a72-a75f-f983237581d0">

Note: Using mock data right now to show both scenarios.
