### PR TITLE
header refactoring

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -220,6 +220,10 @@
   width: 9.375rem;
 }
 
+.block.header .sidepanel .top-area-logo p {
+  margin: 0;
+}
+
 .block.header .sidepanel .bottom-area {
   display: flex;
   flex-direction: column;
@@ -801,6 +805,10 @@
   .block.header .top-bar .logo img {
     width: 15.625rem;
     height: auto;
+  }
+
+  .block.header .top-bar .logo p {
+    margin: 0;
   }
 
   .block.header .top-bar .row1 .primary-buttons button.desktop-element {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -894,7 +894,7 @@ const addHeaderEventHandlers = () => {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta).pathname : '/draft/vivesing/nav';
+  const navPath = navMeta ? new URL(navMeta).pathname : '/nav';
   const fragment = await loadFragment(navPath);
   // Global navigator  starts here
   decorateGlobalNavigationBar(fragment, block);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -47,11 +47,11 @@ const decorateGlobalNavigationBar = (fragment, block) => {
 const decorateMainHeaderLogo = (fragment) => {
   const logoDiv = document.createElement('div');
   logoDiv.className = 'logo';
-  const headerLogoDetails = fragment.querySelector('.section.icici-logo');
-  const imageAltData = headerLogoDetails.getAttribute('data-image-alt');
+  const headerLogoDetails = fragment.querySelector('.section.primary-buttons');
   const imageTag = headerLogoDetails.querySelector('img');
-  imageTag.alt = imageAltData;
-  logoDiv.appendChild(imageTag);
+  imageTag.alt = 'ICICI Logo';
+  const wrappedLogo = headerLogoDetails.querySelector('.button-container');
+  logoDiv.appendChild(wrappedLogo);
   return logoDiv;
 };
 
@@ -341,11 +341,11 @@ const buildSidePanelTopSection = (fragment) => {
 
   const sidePanelTopAreaLogo = document.createElement('div');
   sidePanelTopAreaLogo.className = 'top-area-logo';
-  const sidePanelLogoDetails = fragment.querySelector('.section.side-panel-icici-logo');
-  const sidePanelImageAltData = sidePanelLogoDetails.getAttribute('data-image-alt');
+  const sidePanelLogoDetails = fragment.querySelector('.section.side-panel-primary-actions');
   const sidePanelImageTag = sidePanelLogoDetails.querySelector('img');
-  sidePanelImageTag.alt = sidePanelImageAltData;
-  sidePanelTopAreaLogo.appendChild(sidePanelImageTag);
+  sidePanelImageTag.alt = 'ICICI Logo';
+  const wrappedLogo = sidePanelLogoDetails.querySelector('.button-container');
+  sidePanelTopAreaLogo.appendChild(wrappedLogo);
   sidePanelTopAreaDiv.appendChild(sidePanelTopAreaLogo);
   return sidePanelTopAreaDiv;
 };
@@ -894,7 +894,7 @@ const addHeaderEventHandlers = () => {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta).pathname : '/draft/vivesing/nav';
   const fragment = await loadFragment(navPath);
   // Global navigator  starts here
   decorateGlobalNavigationBar(fragment, block);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://refactor--icicidirect--aemsites.hlx.live/research/equity

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. carousel | [doc-link](https://main--icicidirect--aemsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/carousel&index=0)


Using a cleaner block structure for nav
1. removed the separate section for icici logo
2. order of the section matches the page layout
new nav document - https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/icicidirect/draft/vivesing/nav.docx?d=w6756e952ad79489b98ef94b72236ce45&csf=1&web=1&e=MdlNtwhttps://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/icicidirect/draft/vivesing/

<img width="798" alt="image" src="https://github.com/aemsites/icicidirect/assets/38683124/238c5521-64f5-4dac-a3ce-a13ae635adb5">

