### PR TITLE
Add internal page check to avoid header / footer loading in block library

### DIFF
--- a/scripts/blocks-utils.js
+++ b/scripts/blocks-utils.js
@@ -464,6 +464,23 @@ const handleNoResults = (element) => {
   }
 };
 
+/**
+ * Returns the true of the current page in the browser.
+ * If the page is running in a iframe with srcdoc,
+ * the ancestor origin + the path query param is returned.
+ * @returns {String} The href of the current page or the href of the block running in the library
+ */
+function getHref() {
+  if (window.location.href !== 'about:srcdoc') return window.location.href;
+
+  const urlParams = new URLSearchParams(window.parent.location.search);
+  return `${window.parent.location.origin}${urlParams.get('path')}`;
+}
+
+function isInternalPage() {
+  return getHref().indexOf('/sidekick/blocks/') > 0 || getHref().indexOf('/_tools/') > 0;
+}
+
 export {
   isInViewport,
   Viewport,
@@ -496,4 +513,6 @@ export {
   CONTENT_FEED_URL,
   SOCKET_IO_SCRIPT,
   handleNoResults,
+  getHref,
+  isInternalPage
 };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -17,6 +17,7 @@ import {
   defaultAnalyticsLoadDisabled,
   loadAdobeLaunchAndGTM,
   loadAnalyticsDelayed,
+  isInternalPage,
 } from './blocks-utils.js';
 import { decorateSocialShare } from './social-utils.js';
 
@@ -179,9 +180,10 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadHeader(doc.querySelector('header'));
-  loadFooter(doc.querySelector('footer'));
-
+  if (!isInternalPage()) {
+    loadHeader(doc.querySelector('header'));
+    loadFooter(doc.querySelector('footer'));
+  }
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
 


### PR DESCRIPTION


Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://internal-page--icicidirect--aemsites.hlx.live/research/equity

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. carousel | [doc-link](https://main--icicidirect--aemsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/carousel&index=0)
