### PR TITLE
Preconnect to edge worker

### DIFF
--- a/scripts/blocks-utils.js
+++ b/scripts/blocks-utils.js
@@ -481,6 +481,22 @@ function isInternalPage() {
   return getHref().indexOf('/sidekick/blocks/') > 0 || getHref().indexOf('/_tools/') > 0;
 }
 
+/**
+ * Add prefetch link to the head
+ * @param {*} kind - The kind of prefetch link
+ * @param {*} url - The URL to prefetch
+ * @param {*} as - The as attribute for the prefetch link
+ */
+function addPrefetch(kind, url, as) {
+  const linkEl = document.createElement('link');
+  linkEl.rel = kind;
+  linkEl.href = url;
+  if (as) {
+    linkEl.as = as;
+  }
+  document.head.append(linkEl);
+}
+
 export {
   isInViewport,
   Viewport,
@@ -515,4 +531,5 @@ export {
   handleNoResults,
   getHref,
   isInternalPage,
+  addPrefetch,
 };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -18,6 +18,7 @@ import {
   loadAdobeLaunchAndGTM,
   loadAnalyticsDelayed,
   isInternalPage,
+  addPrefetch,
 } from './blocks-utils.js';
 import { decorateSocialShare } from './social-utils.js';
 
@@ -207,8 +208,7 @@ async function loadPage() {
   await loadLazy(document);
   loadDelayed();
 }
+addPrefetch('preconnect', 'https://icicidirect-secure-worker.franklin-prod.workers.dev');
 loadPage();
-
 window.validateuserToken = '';
-
 window.validateCaptchaToken = '';


### PR DESCRIPTION
Test URLs:
- Before: https://main--icicidirect--aemsites.hlx.live/research/equity
- After: https://preconnect--icicidirect--aemsites.hlx.live/research/equity

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. carousel | [doc-link](https://main--icicidirect--aemsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/carousel&index=0)
